### PR TITLE
feat: implementation map cycle time

### DIFF
--- a/Classes/Map.cs
+++ b/Classes/Map.cs
@@ -2,7 +2,7 @@
 
 namespace MapCycleAndChooser_COFYYE.Classes
 {
-    public class Map(string mapValue, string mapDisplay, bool mapIsWorkshop, string mapWorkshopId, bool mapCycleEnabled, bool mapCanVote, int mapMinPlayers, int mapMaxPlayers)
+    public class Map(string mapValue, string mapDisplay, bool mapIsWorkshop, string mapWorkshopId, bool mapCycleEnabled, bool mapCanVote, int mapMinPlayers, int mapMaxPlayers, string mapCycleStartTime, string mapCycleEndTime)
     {
         [JsonPropertyName("map_value")]
         public string MapValue { get; init; } = mapValue;
@@ -27,5 +27,11 @@ namespace MapCycleAndChooser_COFYYE.Classes
 
         [JsonPropertyName("map_max_players")]
         public int MapMaxPlayers { get; init; } = mapMaxPlayers;
+
+        [JsonPropertyName("map_cycle_start_time")]
+        public string CycleStartTime { get; init; } = mapCycleStartTime;
+
+        [JsonPropertyName("map_cycle_end_time")]
+        public string CycleEndTime { get; init; } = mapCycleEndTime;
     }
 }

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -121,15 +121,15 @@ namespace MapCycleAndChooser_COFYYE.Config
         [JsonPropertyName("maps")]
         public List<Map> Maps { get; init; } =
         [
-            new Map("de_dust2", "De Dust2", false, "", true, true, 0, 64),
-            new Map("de_mirage", "De Mirage", false, "", true, true, 0, 64),
-            new Map("de_vertigo", "De Vertigo", false, "", true, true, 0, 64),
-            new Map("de_overpass", "De Overpass", false, "", true, true, 0, 64),
-            new Map("de_train", "De Train", false, "", true, true, 0, 64),
-            new Map("de_nuke", "De Nuke", false, "", true, true, 0, 64),
-            new Map("de_anubis", "De Anubis", false, "", true, true, 0, 64),
-            new Map("de_ancient", "De Ancient", false, "", true, true, 0, 64),
-            new Map("de_inferno", "De Inferno", false, "", true, true, 0, 64)
+            new Map("de_dust2", "De Dust2", false, "", true, true, 0, 64, "", ""),
+            new Map("de_mirage", "De Mirage", false, "", true, true, 0, 64, "", ""),
+            new Map("de_vertigo", "De Vertigo", false, "", true, true, 0, 64, "", ""),
+            new Map("de_overpass", "De Overpass", false, "", true, true, 0, 64, "", ""),
+            new Map("de_train", "De Train", false, "", true, true, 0, 64, "", ""),
+            new Map("de_nuke", "De Nuke", false, "", true, true, 0, 64, "", ""),
+            new Map("de_anubis", "De Anubis", false, "", true, true, 0, 64, "", ""),
+            new Map("de_ancient", "De Ancient", false, "", true, true, 0, 64, "", ""),
+            new Map("de_inferno", "De Inferno", false, "", true, true, 0, 64, "", "")
         ];
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Join and experience this plugin, along with all the other custom plugins I creat
 - **Real-time Voting Percentages**: View the percentage of votes for each map in real time.  
 - **Admin Map List**: Admins can access a list of available maps and instantly change the current map.  
 - **Dynamic Map Cycle**: Set which maps are part of the cycle and which ones can be changed from the map list.  
+- **Dynamic Map Cycle Time**: Set whether each map is selected as a cycle based on time.  
 - **Dynamic Map Selection**: Maps are selected based on the current number of players, with options for max and min player thresholds.  
 - **Custom Map Display**: Show custom names instead of map values (e.g., showing "Dust II" instead of "de_dust2").  
 - **Round/Timelimit-Based Map Changes**: Change maps based on the number of rounds or time limits.  
@@ -250,6 +251,8 @@ Below is a step-by-step guide explaining the available configuration options for
      - **`map_can_vote`**: `true` if the map should appear in the voting system; `false` if it should not.  
      - **`map_min_players`**: Minimum number of players required for the map to be included in voting.  
      - **`map_max_players`**: Maximum number of players allowed for the map to be included in voting.
+     - **`map_cycle_start_time`**: Start time ("HH:mm" format, other is invalid.) for map cycle. Ignored if start and end fields are empty.
+     - **`map_cycle_end_time`**: End time ("HH:mm" format, other is invalid.) for map cycle. Ignored if start and end fields are empty.
 
 ### Installation
 

--- a/Utils/MapUtils.cs
+++ b/Utils/MapUtils.cs
@@ -7,6 +7,7 @@ using CounterStrikeSharp.API.Modules.Timers;
 using MapCycleAndChooser_COFYYE.Classes;
 using MapCycleAndChooser_COFYYE.Variables;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 
 namespace MapCycleAndChooser_COFYYE.Utils
 {
@@ -24,7 +25,8 @@ namespace MapCycleAndChooser_COFYYE.Utils
                     map.MapValue != Server.MapName &&
                     map.MapCanVote &&
                     map.MapMinPlayers <= currentPlayers &&
-                    map.MapMaxPlayers >= currentPlayers
+                    map.MapMaxPlayers >= currentPlayers &&
+                    CheckMapInCycleTime(map)
                 )
                 .ToList();
 
@@ -84,7 +86,7 @@ namespace MapCycleAndChooser_COFYYE.Utils
                 var ignoreVotePercentage = mapPercentages.GetValueOrDefault("{menu.item.ignore.vote}", 0);
                 if (ignoreVotePercentage == maxPercentage)
                 {
-                    topMaps.Add(new Map("{menu.item.ignore.vote}", "Ignore Vote", false, "", true, true, 0, 64));
+                    topMaps.Add(new Map("{menu.item.ignore.vote}", "Ignore Vote", false, "", true, true, 0, 64, "", ""));
                 }
             }
 
@@ -93,7 +95,7 @@ namespace MapCycleAndChooser_COFYYE.Utils
                 var extendMapPercentage = mapPercentages.GetValueOrDefault("{menu.item.extend.map}", 0);
                 if (extendMapPercentage == maxPercentage)
                 {
-                    topMaps.Add(new Map("{menu.item.extend.map}", "Extend Map", false, "", true, true, 0, 64));
+                    topMaps.Add(new Map("{menu.item.extend.map}", "Extend Map", false, "", true, true, 0, 64, "", ""));
                 }
             }
 
@@ -146,7 +148,7 @@ namespace MapCycleAndChooser_COFYYE.Utils
             }
             else
             {
-                GlobalVariables.NextMap = new Map(Server.MapName, Server.MapName, false, "", false, false, 0, 64);
+                GlobalVariables.NextMap = new Map(Server.MapName, Server.MapName, false, "", false, false, 0, 64, "", "");
             }
         }
 
@@ -400,6 +402,49 @@ namespace MapCycleAndChooser_COFYYE.Utils
             }
 
             return HookResult.Continue;
+        }
+
+        public static bool CheckMapInCycleTime(Map map)
+        {
+            var start = map.CycleStartTime;
+            var end = map.CycleEndTime;
+
+            // if both are empty, lets ignore the setting
+            if (string.IsNullOrWhiteSpace(start) && string.IsNullOrWhiteSpace(end))
+            {
+                return true;
+            }
+            if (string.IsNullOrWhiteSpace(start) || string.IsNullOrWhiteSpace(end))
+            {
+                Instance?.Logger.LogInformation("Either 'cycle_start_time' or 'cycle_end_time' is empty. map: {MapName}", map.MapValue);
+                return false;
+            }
+
+            var now = DateTime.Now;
+            if (!DateTime.TryParseExact(start, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedStart))
+            {
+                Instance?.Logger.LogInformation("The 'cycle_start_time' string is not valid. Format should be 'HH:mm'.");
+                Instance?.Logger.LogInformation("Invalid 'cycle_start_time' config string. map: {MapName}", map.MapValue);
+                return false;
+            }
+            if (!DateTime.TryParseExact(end, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedEnd))
+            {
+                Instance?.Logger.LogInformation("The 'cycle_end_time' string is not valid. Format should be 'HH:mm'.");
+                Instance?.Logger.LogInformation("Invalid 'cycle_end_time' config string. map: {MapName}", map.MapValue);
+                return false;
+            }
+
+            var startTime = now.Date.Add(parsedStart.TimeOfDay);
+            var endTime = now.Date.Add(parsedEnd.TimeOfDay);
+
+            // if 'start' - 'end' into the next day
+            // example: 23:00 - 05:00
+            if (startTime >= endTime)
+            {
+                endTime.AddDays(1);
+            }
+
+            return now >= startTime && now <= endTime;
         }
     }
 }

--- a/Utils/MapUtils.cs
+++ b/Utils/MapUtils.cs
@@ -414,32 +414,16 @@ namespace MapCycleAndChooser_COFYYE.Utils
             {
                 return true;
             }
-            if (string.IsNullOrWhiteSpace(start) || string.IsNullOrWhiteSpace(end))
-            {
-                Instance?.Logger.LogInformation("Either 'cycle_start_time' or 'cycle_end_time' is empty. map: {MapName}", map.MapValue);
-                return false;
-            }
 
             var now = DateTime.Now;
-            if (!DateTime.TryParseExact(start, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedStart))
-            {
-                Instance?.Logger.LogInformation("The 'cycle_start_time' string is not valid. Format should be 'HH:mm'.");
-                Instance?.Logger.LogInformation("Invalid 'cycle_start_time' config string. map: {MapName}", map.MapValue);
-                return false;
-            }
-            if (!DateTime.TryParseExact(end, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedEnd))
-            {
-                Instance?.Logger.LogInformation("The 'cycle_end_time' string is not valid. Format should be 'HH:mm'.");
-                Instance?.Logger.LogInformation("Invalid 'cycle_end_time' config string. map: {MapName}", map.MapValue);
-                return false;
-            }
-
+            var parsedStart = DateTime.ParseExact(start, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None);
+            var parsedEnd = DateTime.ParseExact(start, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None);
             var startTime = now.Date.Add(parsedStart.TimeOfDay);
             var endTime = now.Date.Add(parsedEnd.TimeOfDay);
 
             // if 'start' - 'end' into the next day
             // example: 23:00 - 05:00
-            if (startTime >= endTime)
+            if (startTime > endTime)
             {
                 endTime.AddDays(1);
             }

--- a/Utils/ServerUtils.cs
+++ b/Utils/ServerUtils.cs
@@ -3,6 +3,7 @@ using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Cvars;
 using MapCycleAndChooser_COFYYE.Variables;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 
 namespace MapCycleAndChooser_COFYYE.Utils
 {
@@ -107,7 +108,37 @@ namespace MapCycleAndChooser_COFYYE.Utils
                 Instance?.Logger.LogError("vote_trigger_time_before_map_end has bad value. Value must be greater than 2");
                 throw new ArgumentException(nameof(Instance.Config));
             }
+
+            // Maps
+            foreach (var map in Instance?.Config?.Maps)
+            {
+                // CycleStartTime and CycleEndTime
+                if (map.CycleStartTime == map.CycleEndTime)
+                {
+                    Instance?.Logger.LogInformation("'map_cycle_start_time' and 'map_cycle_end_time' are same. map: {MapName}", map.MapValue);
+                    throw new ArgumentException(nameof(Instance.Config));
+                }
+                if (!string.IsNullOrWhiteSpace(map.CycleStartTime) && string.IsNullOrWhiteSpace(map.CycleEndTime))
+                {
+                    Instance?.Logger.LogInformation("'map_cycle_start_time' is empty. map: {MapName}", map.MapValue);
+                    throw new ArgumentException(nameof(Instance.Config));
+                }
+                if (string.IsNullOrWhiteSpace(map.CycleStartTime) && !string.IsNullOrWhiteSpace(map.CycleEndTime))
+                {
+                    Instance?.Logger.LogInformation("'map_cycle_end_time' is empty. map: {MapName}", map.MapValue);
+                    throw new ArgumentException(nameof(Instance.Config));
+                }
+                if (!DateTime.TryParseExact(map.CycleStartTime, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
+                {
+                    Instance?.Logger.LogInformation("'map_cycle_start_time' has bad value. Value format must be 'HH:mm'. map: {MapName}", map.MapValue);
+                    throw new ArgumentException(nameof(Instance.Config));
+                }
+                if (!DateTime.TryParseExact(map.CycleEndTime, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
+                {
+                    Instance?.Logger.LogInformation("'map_cycle_end_time' has bad value. Value format must be 'HH:mm'. map: {MapName}", map.MapValue);
+                    throw new ArgumentException(nameof(Instance.Config));
+                }
+            }
         }
     }
 }
-


### PR DESCRIPTION
This PR add the map cycle time validation logic and updates the README documentation accordingly.  
This changes makes it possible to control which maps we want to cycle through only at certain times.  
↳ For example, if we have a map that we want to play with a large number of people, we can set it to cycle only during times when there are many people.  
Key changes:  
- `map_cycle_start_time` and `map_cycle_end_time` were added into `Config.maps`
- Validation has also been added for the added Config
- Added settings will be ignored if both are empty strings
- Explanation about Config has been added to README

example json:  
```json
{
  // ...
  "maps": [
    {
      "map_value": "de_dust2",
      "map_display": "Dust II",
      "map_is_workshop": false,
      "map_workshop_id": "",
      "map_cycle_enabled": true,
      "map_can_vote": true,
      "map_min_players": 2,
      "map_max_players": 16,
      "map_cycle_start_time": "12:00",
      "map_cycle_end_time": "18:00"
    },
    {
      "map_value": "de_inferno",
      "map_display": "Inferno",
      "map_is_workshop": false,
      "map_workshop_id": "",
      "map_cycle_enabled": true,
      "map_can_vote": true,
      "map_min_players": 3,
      "map_max_players": 14,
      "map_cycle_start_time": "20:00",
      "map_cycle_end_time": "23:00"
    },
    // ...
  ]
}
```