### PR TITLE
fix: Update for latest CSSharp version

### DIFF
--- a/MapCycleAndChooser-COFYYE.cs
+++ b/MapCycleAndChooser-COFYYE.cs
@@ -11,6 +11,7 @@ using MapCycleAndChooser_COFYYE.Classes;
 using CounterStrikeSharp.API.Modules.Memory;
 using MapCycleAndChooser_COFYYE.Variables;
 using Menu;
+using CounterStrikeSharp.API.Modules.Events;
 namespace MapCycleAndChooser_COFYYE;
 
 public class MapCycleAndChooser : BasePlugin, IPluginConfig<Config.Config>

--- a/MapCycleAndChooser-COFYYE.csproj
+++ b/MapCycleAndChooser-COFYYE.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.305" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.316" />
 	<Reference Include="KitsuneMenu">
 		<HintPath>./shared/KitsuneMenu/KitsuneMenu.dll</HintPath>
 	</Reference>


### PR DESCRIPTION
Plugin version 1.1 causes the following error:
```
22:05:00 [EROR] (cssharp:Core) Error invoking callback
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.TypeLoadException: Could not load type 'CounterStrikeSharp.API.Core.EventPlayerChat' from assembly 'CounterStrikeSharp.API, Version=1.0.316.0, Culture=neutral, PublicKeyToken=null'.
   at MapCycleAndChooser_COFYYE.MapCycleAndChooser.Unload(Boolean hotReload)
   at CounterStrikeSharp.API.Core.Plugin.PluginContext.Unload(Boolean hotReload) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs:line 236
   at CounterStrikeSharp.API.Core.Plugin.PluginContext.<>c__DisplayClass29_0.<OnReloadedAsync>b__0() in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs:line 112
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at CounterStrikeSharp.API.Core.FunctionReference.<CreateWrappedCallback>b__18_0(fxScriptContext* context) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/FunctionReference.cs:line 100
```

This is fixed by updating the project's CSSharp version and importing `CounterStrikeSharp.API.Modules.Events` for the  EventPlayerChat definition.

Forked dev branch this time since #7 was closed. (??)